### PR TITLE
Add simple OpenAI transcription page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Transcribe-
+
+A simple single-page tool to transcribe video or audio files using OpenAI's speech API.
+
+Open `index.html` in a browser, paste your API key, choose your file, select a language (or use Auto) and click **Transcribe**. The app uses the `gpt-4o-transcribe` model with word-level timestamps and speaker diarization. When done a text file of the transcript can be downloaded.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Video Transcriber</title>
+<style>
+body { font-family: Arial, sans-serif; padding: 20px; }
+#transcript span.word { cursor: pointer; }
+#transcript span.highlight { background: yellow; }
+</style>
+</head>
+<body>
+<h1>OpenAI Video Transcriber</h1>
+<label>API Key: <input type="password" id="apiKey"></label><br><br>
+<label>Language:
+<select id="lang">
+  <option value="">Auto</option>
+  <option value="en">English</option>
+  <option value="ar">Arabic</option>
+</select></label><br><br>
+<input type="file" id="fileInput" accept="video/*,audio/*"><br><br>
+<button id="transcribeBtn">Transcribe</button>
+<a id="downloadLink" style="display:none; margin-left:20px;">Download TXT</a>
+
+<h2>Transcript</h2>
+<audio id="player" controls></audio>
+<div id="transcript"></div>
+
+<script>
+async function transcribe() {
+  const fileInput = document.getElementById('fileInput');
+  const apiKey = document.getElementById('apiKey').value.trim();
+  if (!fileInput.files.length || !apiKey) {
+    alert('Please select a file and enter your API key.');
+    return;
+  }
+  const file = fileInput.files[0];
+  document.getElementById('player').src = URL.createObjectURL(file);
+
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('model', 'gpt-4o-transcribe');
+  const lang = document.getElementById('lang').value;
+  if (lang) formData.append('language', lang);
+  formData.append('response_format', 'verbose_json');
+  formData.append('timestamp_granularities[]', 'word');
+  formData.append('diarization', 'speaker');
+
+  const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: { 'Authorization': 'Bearer ' + apiKey },
+    body: formData
+  });
+  if (!response.ok) {
+    const err = await response.text();
+    alert('Error: ' + err);
+    return;
+  }
+  const data = await response.json();
+  buildTranscript(data.segments || [], data.text || '');
+}
+
+function buildTranscript(segments, plainText) {
+  const container = document.getElementById('transcript');
+  container.innerHTML = '';
+  const words = [];
+  let textContent = '';
+  segments.forEach(seg => {
+    const div = document.createElement('div');
+    div.innerHTML = `<strong>${seg.speaker || 'Speaker'}</strong>:`;
+    seg.words.forEach(w => {
+      const span = document.createElement('span');
+      span.className = 'word';
+      span.dataset.start = w.start;
+      span.dataset.end = w.end;
+      span.textContent = w.word;
+      span.onclick = () => {
+        player.currentTime = w.start;
+        player.play();
+      };
+      div.append(' ');
+      div.append(span);
+      words.push(span);
+      textContent += w.word + ' ';
+    });
+    container.append(div);
+  });
+  player.ontimeupdate = () => {
+    const t = player.currentTime;
+    words.forEach(span => {
+      if (t >= parseFloat(span.dataset.start) && t < parseFloat(span.dataset.end)) {
+        span.classList.add('highlight');
+      } else {
+        span.classList.remove('highlight');
+      }
+    });
+  };
+  const blob = new Blob([plainText || textContent.trim()], {type: 'text/plain'});
+  const link = document.getElementById('downloadLink');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'transcript.txt';
+  link.style.display = 'inline';
+  link.textContent = 'Download TXT';
+}
+
+document.getElementById('transcribeBtn').onclick = transcribe;
+const player = document.getElementById('player');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone HTML page for uploading video/audio
- use OpenAI `gpt-4o-transcribe` model with word timestamps and speaker diarization
- allow download of plain text transcript
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3fb79424832d9d31039ad3569503